### PR TITLE
Pass on the config from npm even if we didn't install anything.

### DIFF
--- a/src/steps/npm.js
+++ b/src/steps/npm.js
@@ -33,10 +33,10 @@ export default class NPM extends StepBase {
                     });
                 }
             }
-
-            return chain.then(() => {
-                return previousStepResults;
-            });
         }
+        // pass on config
+        return chain.then(() => {
+            return previousStepResults;
+        });
     }
 }


### PR DESCRIPTION
If we choose to not install anything, the config is not passed on from the npm step, so the PIP step errors.
